### PR TITLE
[casr-ubsan] Always symbolize stack traces (AFL++ fix)

### DIFF
--- a/casr/src/bin/casr-ubsan.rs
+++ b/casr/src/bin/casr-ubsan.rs
@@ -378,9 +378,17 @@ fn main() -> Result<()> {
         } else {
             ubsan_options.push_str(",report_error_type=1");
         }
+        if ubsan_options.contains("symbolize=0") {
+            ubsan_options = ubsan_options.replace("symbolize=0", "symbolize=1");
+        } else {
+            ubsan_options.push_str(",symbolize=1");
+        }
         env::set_var("UBSAN_OPTIONS", ubsan_options);
     } else {
-        env::set_var("UBSAN_OPTIONS", "print_stacktrace=1,report_error_type=1");
+        env::set_var(
+            "UBSAN_OPTIONS",
+            "print_stacktrace=1,report_error_type=1,symbolize=1",
+        );
     }
 
     // Extract ubsan warnings


### PR DESCRIPTION
AFL++ removes symbols from stack traces by default. This patch always enables them for proper crash line detection.