### PR TITLE
Security predicates tags.

### DIFF
--- a/casr/src/bin/casr-dojo.rs
+++ b/casr/src/bin/casr-dojo.rs
@@ -273,6 +273,18 @@ impl DefectDojoClient {
         if !report.stdin.is_empty() {
             reproduce += &format!(" < {}", report.stdin);
         }
+
+        let security_re = Regex::new(
+            "null_deref|out_of_bounds|int_overflow|div_by_zero|invalid_hep|neg_size|num_trunc",
+        )
+        .unwrap();
+        if security_re.is_match(&reproduce) {
+            findings.insert(
+                "tags".to_string(),
+                serde_json::Value::Array(["sydr-security"]),
+            );
+        }
+
         finding.insert(
             "steps_to_reproduce".to_string(),
             serde_json::Value::String(reproduce),

--- a/casr/src/bin/casr-dojo.rs
+++ b/casr/src/bin/casr-dojo.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, Result};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
 use clap::{Arg, ArgAction};
 use log::{debug, error, info, warn};
+use regex::Regex;
 use reqwest::header::{HeaderMap, AUTHORIZATION};
 use reqwest::{Client, Method, RequestBuilder, Response, Url};
 use walkdir::WalkDir;
@@ -280,7 +281,9 @@ impl DefectDojoClient {
         if security_re.is_match(&reproduce) {
             finding.insert(
                 "tags".to_string(),
-                serde_json::Value::Array(["sydr-security"]),
+                serde_json::Value::Array(vec![serde_json::Value::String(
+                    "sydr-security".to_string(),
+                )]),
             );
         }
 

--- a/casr/src/bin/casr-dojo.rs
+++ b/casr/src/bin/casr-dojo.rs
@@ -278,7 +278,7 @@ impl DefectDojoClient {
             Regex::new("null_deref|out_of_bounds|int_overflow|div_by_zero|neg_size|num_trunc")
                 .unwrap();
         if security_re.is_match(&reproduce) {
-            findings.insert(
+            finding.insert(
                 "tags".to_string(),
                 serde_json::Value::Array(["sydr-security"]),
             );

--- a/casr/src/bin/casr-dojo.rs
+++ b/casr/src/bin/casr-dojo.rs
@@ -275,7 +275,7 @@ impl DefectDojoClient {
         }
 
         let security_re = Regex::new(
-            "null_deref|out_of_bounds|int_overflow|div_by_zero|invalid_hep|neg_size|num_trunc",
+            "null_deref|out_of_bounds|int_overflow|div_by_zero|neg_size|num_trunc",
         )
         .unwrap();
         if security_re.is_match(&reproduce) {

--- a/casr/src/bin/casr-dojo.rs
+++ b/casr/src/bin/casr-dojo.rs
@@ -274,10 +274,9 @@ impl DefectDojoClient {
             reproduce += &format!(" < {}", report.stdin);
         }
 
-        let security_re = Regex::new(
-            "null_deref|out_of_bounds|int_overflow|div_by_zero|neg_size|num_trunc",
-        )
-        .unwrap();
+        let security_re =
+            Regex::new("null_deref|out_of_bounds|int_overflow|div_by_zero|neg_size|num_trunc")
+                .unwrap();
         if security_re.is_match(&reproduce) {
             findings.insert(
                 "tags".to_string(),


### PR DESCRIPTION
Add `sydr-security` tag for inputs generated by Sydr security predicates.