### PR TITLE
Fix casr-ubsan test

### DIFF
--- a/casr/tests/tests.rs
+++ b/casr/tests/tests.rs
@@ -3540,6 +3540,8 @@ fn test_casr_ubsan() {
     let work_dir = abs_path("tests/casr_tests/ubsan");
     let test_dir = abs_path("tests/tmp_tests_casr/test_casr_ubsan");
 
+    let _ = fs::remove_dir_all(&test_dir);
+
     let output = Command::new("cp")
         .args(["-r", &work_dir, &test_dir])
         .output()
@@ -3625,8 +3627,6 @@ fn test_casr_ubsan() {
         .unwrap();
 
     assert_eq!(unique_cnt, 2, "Invalid number of deduplicated reports");
-
-    let _ = fs::remove_dir_all(&test_dir);
 }
 
 #[test]


### PR DESCRIPTION
I was running tests local and found this problem:

```
failures:

---- test_casr_ubsan stdout ----
thread 'test_casr_ubsan' panicked at 'Stdout .
 Stderr: mkdir: cannot create directory ‘/home/fedotoff/casr/casr/tests/tmp_tests_casr/test_casr_ubsan/out’: File exists
', casr/tests/tests.rs:3569:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This fix could help, I think.