### PR TITLE
Update docs: add cargo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ or build from source as explained below.
 Build from Git repository:
 
     $ git clone https://github.com/ispras/casr
+    $ cargo update
     $ cargo build --release
 
 Or you may just install Casr from [crates.io](https://crates.io/crates/casr):


### PR DESCRIPTION
Running cargo update is useful to fetch recent gdb-command release