### PR TITLE
Run hanging LD_PRELOAD tests in coverage workflow on Ubuntu 20.04

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -11,13 +11,14 @@ env:
 jobs:
   ubuntu-latest:
 
-    runs-on: ubuntu-latest
+    # Tests that use LD_PRELOAD are run only on Ubuntu 20.04, see #208
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4
     - name: Install Dependences
       run: |
-        sudo apt update && sudo apt install -y gdb pip curl python3.10-dev llvm \
+        sudo apt update && sudo apt install -y gdb pip curl python3.9-dev llvm \
             openjdk-17-jdk ca-certificates gnupg
         pip3 install atheris
         sudo mkdir -p /etc/apt/keyrings

--- a/casr/Cargo.toml
+++ b/casr/Cargo.toml
@@ -52,3 +52,4 @@ required-features = ["dojo"]
 
 [dev-dependencies]
 lazy_static = "1.4"
+lsb_release = "0.1"

--- a/casr/tests/tests.rs
+++ b/casr/tests/tests.rs
@@ -4049,6 +4049,10 @@ fn test_casr_libfuzzer() {
 #[test]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_libfuzzer_atheris() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     use std::collections::HashMap;
 
     let paths = [
@@ -4233,9 +4237,12 @@ fn test_casr_java() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_java_native_lib() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     let paths = [
         abs_path("tests/casr_tests/java/Test2.java"),
         abs_path("tests/casr_tests/java/Test2.cpp"),
@@ -4369,9 +4376,12 @@ fn test_casr_python_atheris() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_san_python_df() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // Double free python C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/python");
@@ -4477,9 +4487,12 @@ fn test_casr_san_python_df() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_san_atheris_df() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // Double free python C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/python");
@@ -4589,9 +4602,12 @@ fn test_casr_san_atheris_df() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_python_call_san_df() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // Double free python C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/python");
@@ -4959,9 +4975,12 @@ fn test_casr_js_jazzer() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_js_native() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // JS C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/js");
@@ -5095,9 +5114,12 @@ fn test_casr_js_native() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_js_native_jsfuzz() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // JS jsfuzz C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/js");
@@ -5231,9 +5253,12 @@ fn test_casr_js_native_jsfuzz() {
 }
 
 #[test]
-#[ignore]
 #[cfg(target_arch = "x86_64")]
 fn test_casr_js_native_jazzer() {
+    if lsb_release::info().unwrap().version == "22.04" {
+        // LD_PRELOAD hangs, see #208
+        return;
+    }
     // JS jsfuzz C extension test
     // Copy files to tmp dir
     let work_dir = abs_path("tests/casr_tests/js");


### PR DESCRIPTION
Should later be fixed in #208