### PR TITLE
[casr-cluster] [diff] Use create_dir_all instead of create_dir

### DIFF
--- a/casr/src/bin/casr-cluster.rs
+++ b/casr/src/bin/casr-cluster.rs
@@ -243,7 +243,7 @@ fn merge_or_diff(input: &Path, output: &Path, diff: Option<&Path>) -> Result<u64
     })?;
 
     let save_dir = if let Some(diff) = diff {
-        fs::create_dir(diff)?;
+        fs::create_dir_all(diff)?;
         diff
     } else {
         output


### PR DESCRIPTION
create_dir produces "File exists" error when output directory is already created by user