### PR TITLE
Abort if the cluster exists when clustering

### DIFF
--- a/casr/src/bin/casr-cluster.rs
+++ b/casr/src/bin/casr-cluster.rs
@@ -75,7 +75,7 @@ fn make_clusters(
     // Get clusters
     let (clusters, before, after) = Cluster::cluster_reports(&casreps, 0, dedup)?;
     // Save clusters
-    util::save_clusters(&clusters, outpath, False)?;
+    util::save_clusters(&clusters, outpath, false)?;
 
     Ok((clusters.len(), before, after))
 }
@@ -524,7 +524,7 @@ fn hierarchical_accumulation(
             )?;
         }
     }
-    util::save_clusters(&news, dir, True)?;
+    util::save_clusters(&news, dir, true)?;
     Ok((moved, removed, news.len(), before, before - deduplicated))
 }
 

--- a/casr/src/bin/casr-cluster.rs
+++ b/casr/src/bin/casr-cluster.rs
@@ -75,7 +75,7 @@ fn make_clusters(
     // Get clusters
     let (clusters, before, after) = Cluster::cluster_reports(&casreps, 0, dedup)?;
     // Save clusters
-    util::save_clusters(&clusters, outpath)?;
+    util::save_clusters(&clusters, outpath, False)?;
 
     Ok((clusters.len(), before, after))
 }
@@ -524,7 +524,7 @@ fn hierarchical_accumulation(
             )?;
         }
     }
-    util::save_clusters(&news, dir)?;
+    util::save_clusters(&news, dir, True)?;
     Ok((moved, removed, news.len(), before, before - deduplicated))
 }
 

--- a/casr/src/util.rs
+++ b/casr/src/util.rs
@@ -534,13 +534,17 @@ pub fn load_cluster(dir: &Path, jobs: usize) -> Result<Cluster> {
 /// * `dir` - out directory
 ///
 /// * `cluster_can_exist` - bail if cluster folder exists
-pub fn save_clusters(clusters: &HashMap<usize, Cluster>, dir: &Path, cluster_can_exist: bool) -> Result<()> {
+pub fn save_clusters(
+    clusters: &HashMap<usize, Cluster>,
+    dir: &Path,
+    cluster_can_exist: bool,
+) -> Result<()> {
     for cluster in clusters.values() {
         let cdir = format!("{}/cl{}", &dir.display(), cluster.number);
         if !cluster_can_exist && Path::new(&cdir).exists() {
             bail!("Cluster directory {} already exists, aborting", cdir);
         }
-        
+
         fs::create_dir_all(&cdir)?;
         for casrep in cluster.paths() {
             fs::copy(

--- a/casr/src/util.rs
+++ b/casr/src/util.rs
@@ -532,16 +532,22 @@ pub fn load_cluster(dir: &Path, jobs: usize) -> Result<Cluster> {
 /// * `clusters` - given `Cluster` structures for saving
 ///
 /// * `dir` - out directory
-pub fn save_clusters(clusters: &HashMap<usize, Cluster>, dir: &Path) -> Result<()> {
+///
+/// * `cluster_can_exist` - bail if cluster folder exists
+pub fn save_clusters(clusters: &HashMap<usize, Cluster>, dir: &Path, cluster_can_exist: bool) -> Result<()> {
     for cluster in clusters.values() {
-        fs::create_dir_all(format!("{}/cl{}", &dir.display(), cluster.number))?;
+        let cdir = format!("{}/cl{}", &dir.display(), cluster.number);
+        if !cluster_can_exist && Path::new(&cdir).exists() {
+            bail!("Cluster directory {} already exists, aborting", cdir);
+        }
+        
+        fs::create_dir_all(&cdir)?;
         for casrep in cluster.paths() {
             fs::copy(
                 casrep,
                 format!(
-                    "{}/cl{}/{}",
-                    &dir.display(),
-                    cluster.number,
+                    "{}/{}",
+                    &cdir,
                     &casrep.file_name().unwrap().to_str().unwrap()
                 ),
             )?;


### PR DESCRIPTION
While the issue #271 mentions a warning, there seems to be no reason to warn when doing an incorrect merge. This patch bails if the output cluster directory exists.

In the unlikely case that cl1 does not exist, but cl2 does, cl1 will be created and then left as we bail. Solving this unlikely scenario would require an initial check-exists-loop which does not really make sense.

